### PR TITLE
Support x86 and Debug on Linux and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,25 @@ matrix:
    include:
 
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49
+        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49 CONAN_ARCHS=x86
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
+        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49 CONAN_ARCHS=x86_64
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63
+        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_ARCHS=x86
       - <<: *linux
-        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
+        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54 CONAN_ARCHS=x86_64
       - <<: *linux
-        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
+        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_ARCHS=x86
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63 CONAN_ARCHS=x86_64
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39 CONAN_ARCHS=x86
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39 CONAN_ARCHS=x86_64
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40 CONAN_ARCHS=x86
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40 CONAN_ARCHS=x86_64
 
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-          CONAN_VISUAL_VERSIONS: 12
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,17 @@ environment:
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-  
+
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools
   - conan user # It creates the conan data directory
-  
+
 test_script:
   - python build.py
- 

--- a/build.py
+++ b/build.py
@@ -1,29 +1,44 @@
 from conan.packager import ConanMultiPackager, os, re
 
 
-if __name__ == "__main__":
+def get_name_version_from_recipe():
+    with open("conanfile.py", "r") as conanfile:
+        contents = conanfile.read()
+        name = re.search(r'name\s*=\s*"(\S*)"', contents).groups()[0]
+        version = re.search(r'version\s*=\s*"(\S*)"', contents).groups()[0]
+    return name, version
+
+def get_default_vars():
+    username = os.getenv("CONAN_USERNAME", "bincrafters")
+    channel = os.getenv("CONAN_CHANNEL", "testing")
+    _, version = get_name_version_from_recipe()
+    return username, channel, version
+
+def is_ci_running():
+    return os.getenv("APPVEYOR_REPO_NAME","") or os.getenv("TRAVIS_REPO_SLUG","")
+
+def get_ci_vars():
     reponame_a = os.getenv("APPVEYOR_REPO_NAME","")
     repobranch_a = os.getenv("APPVEYOR_REPO_BRANCH","")
 
     reponame_t = os.getenv("TRAVIS_REPO_SLUG","")
     repobranch_t = os.getenv("TRAVIS_BRANCH","")
 
-    if reponame_t or reponame_a:
-        username, repo = reponame_a.split("/") if reponame_a else reponame_t.split("/")
-        channel, version = repobranch_a.split("/") if repobranch_a else repobranch_t.split("/")
+    username, _ = reponame_a.split("/") if reponame_a else reponame_t.split("/")
+    channel, version = repobranch_a.split("/") if repobranch_a else repobranch_t.split("/")
+    return username, channel, version
 
-        with open("conanfile.py", "r") as conanfile:
-            contents = conanfile.read()
-            name = re.search(r'name\s*=\s*"(\S*)"', contents).groups()[0]
+def get_env_vars():
+    return get_ci_vars() if is_ci_running() else get_default_vars()
 
-        os.environ["CONAN_USERNAME"] = username
-        os.environ["CONAN_CHANNEL"] = channel
-        os.environ["CONAN_REFERENCE"] = "{0}/{1}".format(name, version)
-        os.environ["CONAN_UPLOAD"]="https://api.bintray.com/conan/{0}/public-conan".format(username)
-        os.environ["CONAN_REMOTES"]="https://api.bintray.com/conan/conan-community/conan"
-        os.environ["CONAN_STABLE_BRANCH_PATTERN"] = "stable/*"
-        os.environ["CONAN_UPLOAD_ONLY_WHEN_STABLE"] = "TRUE"
+if __name__ == "__main__":
+    name, _ = get_name_version_from_recipe()
+    username, channel, version = get_env_vars()
+    reference = "{0}/{1}".format(name, version)
+    upload = "https://api.bintray.com/conan/{0}/public-conan".format(username)
 
-    builder = ConanMultiPackager(args="--build missing")
-    builder.add_common_builds(shared_option_name="Azure-C-Shared-Utility:shared")
+    builder = ConanMultiPackager(args="--build missing", username=username, channel=channel,
+                                reference=reference, upload=upload, upload_only_when_stable=True,
+                                stable_branch_pattern="stable/*")
+    builder.add_common_builds(shared_option_name="%s:shared" % name)
     builder.run()

--- a/build.py
+++ b/build.py
@@ -24,6 +24,6 @@ if __name__ == "__main__":
         os.environ["CONAN_STABLE_BRANCH_PATTERN"] = "stable/*"
         os.environ["CONAN_UPLOAD_ONLY_WHEN_STABLE"] = "TRUE"
 
-    builder = ConanMultiPackager(args="--build missing", archs=["x86_64"], build_types=["Release"])
+    builder = ConanMultiPackager(args="--build missing")
     builder.add_common_builds(shared_option_name="Azure-C-Shared-Utility:shared")
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,12 +23,15 @@ class AzureCSharedUtilityConan(ConanFile):
 
     def requirements(self):
         if self.settings.os == "Linux" or self.settings.os == "Macos":
-            self.requires.add("OpenSSL/1.0.2l@conan/stable")
+            self.requires.add("libcurl/7.50.3@lasote/stable")
+            self.requires.add("OpenSSL/1.0.2l@conan/stable", override=True)
+            self.requires.add("zlib/1.2.11@conan/stable", override=True)
 
     def system_requirements(self):
         if self.settings.os == "Linux":
             package_tool = tools.SystemPackageTool()
-            package_tool.install(packages="libcurl4-gnutls-dev uuid-dev pkg-config")
+            arch = "amd64" if self.settings.arch == "x86_64" else "i386"
+            package_tool.install(packages="uuid-dev:%s pkg-config" % arch)
 
     def build(self):
         conan_magic_lines = '''project(%s)
@@ -59,6 +62,5 @@ class AzureCSharedUtilityConan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("curl")
             self.cpp_info.libs.append("uuid")
             self.cpp_info.libs.append("m")

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,6 +52,7 @@ class AzureCSharedUtilityConan(ConanFile):
         self.copy(pattern="*", dst="include", src=path.join(self.release_name, "inc"))
         self.copy(pattern="azure_c_shared_utilityConfig.cmake", dst="res", src=".")
         self.copy(pattern="azure_c_shared_utilityFunctions.cmake", dst="res", src=path.join(self.release_name, "configs"))
+        self.copy(pattern="azure_iot_build_rules.cmake", dst="res", src=path.join(self.release_name, "configs"))
         self.copy(pattern="*.lib", dst="lib", src="lib", keep_path=False)
         self.copy(pattern="*.dll", dst="bin", src="bin", keep_path=False)
         self.copy(pattern="*.a", dst="lib", src="lib", keep_path=False)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,18 +1,12 @@
 project(test_package)
 cmake_minimum_required(VERSION 2.8.11)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
-
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
-file(GLOB SOURCE_FILES *.c)
-set(CMAKE_VERBOSE_MAKEFILE ON)
+add_executable(${CMAKE_PROJECT_NAME} test_package.c)
 
-add_executable(${CMAKE_PROJECT_NAME} ${SOURCE_FILES})
-
+target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS})
 IF(WIN32)
-	set(OS_LINK_LIBS crypt32 ws2_32 secur32 advapi32 ncrypt winhttp)
+	target_link_libraries(${CMAKE_PROJECT_NAME} crypt32 ws2_32 secur32 advapi32 ncrypt winhttp)
 ENDIF(WIN32)
-
-target_link_libraries(${CMAKE_PROJECT_NAME} ${CONAN_LIBS} ${OS_LINK_LIBS} )

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,5 +1,6 @@
-from conans import ConanFile, CMake
+from conans import ConanFile, CMake, tools, RunEnvironment
 import os
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
@@ -7,13 +8,13 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        cmake.verbose = True
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy("*.dll", dst="bin", src="bin")
-        self.copy("*.dylib*", dst="bin", src="lib")
-        self.copy("*.so*", dst="bin", src="lib")
-
     def test(self):
-        self.run(os.path.join("bin","test_package"))
+        with tools.environment_append(RunEnvironment(self).vars):
+            if self.settings.os == "Windows":
+                self.run(os.path.join("bin","test_package"))
+            else:
+                self.run("DYLD_LIBRARY_PATH=%s %s"%(os.environ['DYLD_LIBRARY_PATH'],os.path.join("bin","test_package")))


### PR DESCRIPTION
To solve libcurl dependency, I used lasote's recipe, it fits well. Also libuuid should be solved by arch, so I divided Linux jobs for x86 and x86_64.

When I tried to build uMQTT 1.0.46 on my environment, it required azure_iot_build_rules.cmake from C shared utility, so I added this new file.